### PR TITLE
Bugfix/demo fixes

### DIFF
--- a/examples/04_illum_demo.ipynb
+++ b/examples/04_illum_demo.ipynb
@@ -442,7 +442,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "anim.save('depth_anim.gif', writer='imagemagick', fps=10)"
+    "anim.save('depth_anim.gif', writer='pillow', fps=10)"
    ]
   }
  ],

--- a/examples/04_illum_demo.ipynb
+++ b/examples/04_illum_demo.ipynb
@@ -36,7 +36,7 @@
     "try:\n",
     "    import plenopticam as pcam\n",
     "except ImportError:\n",
-    "    !pip install plenopticam>=0.6.4\n",
+    "    !pip install 'plenopticam>=0.6.4'\n",
     "    import plenopticam as pcam\n",
     "print('PlenoptiCam v'+pcam.__version__+'\\n')\n",
     "\n",


### PR DESCRIPTION
Hi @hahnec 

Two minor fixes in `examples/04_illum_demo.ipynb`:

 - `'imagemagick'` writer doesn't seem to be working, replaced to `'pillow'` which is working well
![image](https://user-images.githubusercontent.com/48438323/112218974-4e908880-8c1c-11eb-823b-b4ab86b40b69.png)

 - `plenopticam` dependency installation via `!pip install plenopticam>=0.6.4` will not install version >=0.6.4 but will **redirect the standard output of `pip` to a file `=0.6.4`**. The package name and the version should be put between apostrophes.
![image](https://user-images.githubusercontent.com/48438323/112219198-96afab00-8c1c-11eb-8b94-60058cdbae4c.png)

Changes can be tested at https://colab.research.google.com/github/toth2peter/plenopticam/blob/bugfix/demo-fixes/examples/04_illum_demo.ipynb

Should you request any changes at this Pull Request please contact me, thanks in advance.